### PR TITLE
Add option for skipping removal of dom node in etch.destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ let component = new MyComponent({greeting: 'Hello'})
 console.log(component.element.outerHTML) // ==> <div>Hello World!</div>
 ```
 
-#### `etch.update(component)`
+#### `etch.update(component[, replaceNode])`
 
-This function takes a component that is already associated with an `.element` property and updates the component's DOM element based on the current return value of the component's `render` method.
+This function takes a component that is already associated with an `.element` property and updates the component's DOM element based on the current return value of the component's `render` method. If the return value of `render` specifies that the DOM element type has changed since the last `render`, Etch will switch out the previous DOM node for the new one unless `replaceNode` is `false`.
 
 `etch.update` is asynchronous, batching multiple DOM updates together in a single animation frame for efficiency. Even if it is called repeatedly with the same component in a given event-loop tick, it will only perform a single DOM update per component on the next animation frame. That means it is safe to call `etch.update` whenever your component's state changes, even if you're doing so redundantly. This function returns a promise that resolves when the DOM update has completed.
 
@@ -134,11 +134,9 @@ console.log(component.element.outerHTML) // ==> <div>Salutations World!</div>
 
 There is also a synchronous variant, `etch.updateSync`, which performs the DOM update immediately. It doesn't skip redundant updates or batch together with other component updates, so you shouldn't really use it unless you have a clear reason.
 
-One caveat is that it's not possible to update the root tag name of a component. This is because we want to maintain a 1:1 relationship between components and their elements, and changing the root tag name would require us to replace the component's element with a new one. While this is certainly doable, it comes with complexity trade-offs we're not currently willing to make. Instead of swapping root tags, implement subtrees of your DOM that change their root tag as method calls on another component rather than their own components.
+#### `etch.destroy(component[, removeNode])`
 
-#### `etch.destroy(component)`
-
-When you no longer need a component, pass it to `etch.destroy`. This function will remove the component from the document and call `destroy` on any child components (child components are covered later in this document). `etch.destroy` is also asynchronous so that it can combine the removal of DOM elements with other DOM updates, and it returns a promise that resolves when the removal has completed.
+When you no longer need a component, pass it to `etch.destroy`. This function will call `destroy` on any child components (child components are covered later in this document), and will additionally remove the component's DOM element from the document unless `removeNode` is `false`. `etch.destroy` is also asynchronous so that it can combine the removal of DOM elements with other DOM updates, and it returns a promise that resolves when the component destruction process has completed.
 
 `etch.destroy` is typically called in an async `destroy` method on the component:
 

--- a/src/component-helpers.js
+++ b/src/component-helpers.js
@@ -112,15 +112,15 @@ export function updateSync (component) {
 // If called as the result of destroying a component higher in the DOM, the
 // element is not removed to avoid redundant DOM manipulation. Returns a promise
 // that resolves when the destruction is completed.
-export function destroy (component) {
+export function destroy (component, remove=true) {
   if (syncUpdatesInProgressCounter > 0 || syncDestructionsInProgressCounter > 0) {
-    destroySync(component)
+    destroySync(component, remove)
     return Promise.resolve()
   }
 
   let scheduler = getScheduler()
   scheduler.updateDocument(function () {
-    destroySync(component)
+    destroySync(component, remove)
   })
   return scheduler.getNextUpdatePromise()
 }
@@ -129,10 +129,10 @@ export function destroy (component) {
 //
 // Note that we track whether `destroy` calls are in progress and only remove
 // the element if we are not a nested call.
-export function destroySync (component) {
+export function destroySync (component, remove=true) {
   syncDestructionsInProgressCounter++
   destroyChildComponents(component.virtualElement)
-  if (syncDestructionsInProgressCounter === 1) component.element.remove()
+  if (syncDestructionsInProgressCounter === 1 && remove) component.element.remove()
   syncDestructionsInProgressCounter--
 }
 

--- a/src/component-helpers.js
+++ b/src/component-helpers.js
@@ -50,9 +50,9 @@ export function initialize(component) {
 //
 // Returns a promise that will resolve when the requested update has been
 // completed.
-export function update (component) {
+export function update (component, replace=true) {
   if (syncUpdatesInProgressCounter > 0) {
-    updateSync(component)
+    updateSync(component, replace)
     return Promise.resolve()
   }
 
@@ -62,7 +62,7 @@ export function update (component) {
     componentsWithPendingUpdates.add(component)
     scheduler.updateDocument(function () {
       componentsWithPendingUpdates.delete(component)
-      updateSync(component)
+      updateSync(component, replace)
     })
   }
 
@@ -88,7 +88,7 @@ export function update (component) {
 // For now, etch does not allow the root tag of the `render` method to change
 // between invocations, because we want to preserve a one-to-one relationship
 // between component objects and DOM elements for simplicity.
-export function updateSync (component) {
+export function updateSync (component, replace=true) {
   syncUpdatesInProgressCounter++
 
   let oldVirtualElement = component.virtualElement
@@ -98,8 +98,10 @@ export function updateSync (component) {
   let newDomNode = patch(component.element, diff(oldVirtualElement, newVirtualElement))
   refsStack.pop()
   component.virtualElement = newVirtualElement
-  if (newDomNode !== oldDomNode) {
+  if (newDomNode !== oldDomNode && !replace) {
     throw new Error("etch does not support changing the root DOM node type of a component")
+  } else {
+    component.element = newDomNode
   }
 
   syncUpdatesInProgressCounter--

--- a/test/unit/destroy-sync.test.js
+++ b/test/unit/destroy-sync.test.js
@@ -2,7 +2,7 @@
 
 import etch from '../../src/index'
 
-describe('etch.destroy(component)', () => {
+describe('etch.destroySync(component)', () => {
   it('synchronously removes the component\'s element from the document and calls `destroy` on child components', () => {
     class ParentComponent {
       constructor () {
@@ -57,5 +57,29 @@ describe('etch.destroy(component)', () => {
     expect(child.destroyCallCount).to.equal(1) // But we do call it on child components
     expect(parent.element.parentElement).to.be.null
     expect(child.element.parentElement).not.to.be.null // Only removes the root node to avoid unnecessary DOM writes
+  })
+
+  it('does not remove the DOM node when passed false as a second argument', () => {
+    class Component {
+      constructor () {
+        etch.initialize(this)
+      }
+
+      render () {
+        return (
+          <div />
+        )
+      }
+
+      update () {}
+    }
+
+    let component = new Component()
+    let container = document.createElement('div')
+    container.appendChild(component.element)
+
+    etch.destroySync(component, false)
+
+    expect(component.element.parentElement).to.equal(container)
   })
 })

--- a/test/unit/destroy.test.js
+++ b/test/unit/destroy.test.js
@@ -58,4 +58,28 @@ describe('etch.destroy(component)', () => {
     expect(parent.element.parentElement).to.be.null
     expect(child.element.parentElement).not.to.be.null // Only removes the root node to avoid unnecessary DOM writes
   })
+
+  it('does not remove the DOM node when passed false as a second argument', async () => {
+    class Component {
+      constructor () {
+        etch.initialize(this)
+      }
+
+      render () {
+        return (
+          <div />
+        )
+      }
+
+      update () {}
+    }
+
+    let component = new Component()
+    let container = document.createElement('div')
+    container.appendChild(component.element)
+
+    await etch.destroy(component, false)
+
+    expect(component.element.parentElement).to.equal(container)
+  })
 })

--- a/test/unit/update.test.js
+++ b/test/unit/update.test.js
@@ -174,7 +174,7 @@ describe('etch.update(component)', () => {
     expect(parent.element.innerHTML).to.equal('')
   })
 
-  it('throws when attempting to change the top-level node type', () => {
+  it('replaces the DOM when changing the top-level node type', () => {
     class Component {
       constructor () {
         this.renderDiv = true
@@ -193,10 +193,38 @@ describe('etch.update(component)', () => {
     }
 
     let component = new Component()
+    expect(component.element.tagName).to.equal('DIV')
     component.renderDiv = false
 
-    expect(() => {
-      etch.updateSync(component)
-    }).to.throw(/root DOM node type/)
+    etch.updateSync(component)
+    expect(component.element.tagName).to.equal('SPAN')
+  })
+
+  describe('when passing false as the second argument', () => {
+    it('throws when attempting to change the top-level node type', () => {
+      class Component {
+        constructor () {
+          this.renderDiv = true
+          etch.initialize(this)
+        }
+
+        render () {
+          if (this.renderDiv) {
+            return <div />
+          } else {
+            return <span />
+          }
+        }
+
+        update () {}
+      }
+
+      let component = new Component()
+      component.renderDiv = false
+
+      expect(() => {
+        etch.updateSync(component, false)
+      }).to.throw(/root DOM node type/)
+    })
   })
 })


### PR DESCRIPTION
Certain APIs like Atom's block decoration expect to own the element. This adds an option to etch.destroy to keep from removing the DOM node.