### PR TITLE
Update repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nathansobo/etch.git"
+    "url": "https://github.com/atom/etch.git"
   },
   "keywords": [
     "virtual-dom dom view element custom-elements dom-diff atom electron"
@@ -21,9 +21,9 @@
   "author": "Nathan Sobo <nathan@github.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nathansobo/etch/issues"
+    "url": "https://github.com/atom/etch/issues"
   },
-  "homepage": "https://github.com/nathansobo/etch",
+  "homepage": "https://github.com/atom/etch",
   "devDependencies": {
     "babel": "^5.0.0",
     "babel-eslint": "^4.0.5",


### PR DESCRIPTION
Just noticed Etch got moved into the Atom organization, but the old repo URLs are still present in `package.json`. This PR addresses that.

**NOTE:** I did not touch the `author` field, since I wasn't sure whether that should/needs to remain unchanged because of npm.

/cc @nathansobo 