### PR TITLE
Add etch.onUpdate(component, hook) for update notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ console.log(component.element.outerHTML) // ==> <div>Salutations World!</div>
 
 There is also a synchronous variant, `etch.updateSync`, which performs the DOM update immediately. It doesn't skip redundant updates or batch together with other component updates, so you shouldn't really use it unless you have a clear reason.
 
+##### `etch.onUpdate(component, callback)`
+
+If you need to be notified when a component has been updated via `etch.update` or `etch.updateSync`, you can use `etch.onUpdate` to register a function to be called in those scenarios. Multiple functions can be registered per component, and the functions will be run in the same order that they are registered.
+
 #### `etch.destroy(component[, removeNode])`
 
 When you no longer need a component, pass it to `etch.destroy`. This function will call `destroy` on any child components (child components are covered later in this document), and will additionally remove the component's DOM element from the document unless `removeNode` is `false`. `etch.destroy` is also asynchronous so that it can combine the removal of DOM elements with other DOM updates, and it returns a promise that resolves when the component destruction process has completed.

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import dom from './dom'
-import {initialize, update, updateSync, destroy, destroySync} from './component-helpers'
+import {initialize, update, updateSync, destroy, destroySync, onUpdate} from './component-helpers'
 import {setScheduler, getScheduler} from './scheduler-assignment'
 
 let etch = {
   dom,
-  initialize, update, updateSync, destroy, destroySync,
+  initialize, update, updateSync, destroy, destroySync, onUpdate,
   setScheduler, getScheduler
 }
 

--- a/test/unit/update-sync.test.js
+++ b/test/unit/update-sync.test.js
@@ -45,4 +45,36 @@ describe('etch.updateSync(component)', () => {
     etch.updateSync(component)
     expect(component.element.textContent).to.equal('Goodnight Moon')
   });
+
+  it('calls onUpdate hooks in most-recently-added order', () => {
+    let events = []
+    let thisBinding = null
+
+    class MyComponent {
+      constructor () {
+        etch.onUpdate(this, this.onUpdateOne)
+        etch.onUpdate(this, this.onUpdateTwo)
+        etch.initialize(this)
+      }
+
+      onUpdateOne () {
+        events.push('update 1')
+        thisBinding = this
+      }
+
+      onUpdateTwo () {
+        events.push('update 2')
+      }
+
+      update () {}
+
+      render () { return <div /> }
+    }
+
+    let component = new MyComponent()
+    expect(events).to.eql([])
+    etch.updateSync(component)
+    expect(events).to.eql(['update 1', 'update 2'])
+    expect(thisBinding).to.equal(component)
+  })
 });

--- a/test/unit/update.test.js
+++ b/test/unit/update.test.js
@@ -227,4 +227,40 @@ describe('etch.update(component)', () => {
       }).to.throw(/root DOM node type/)
     })
   })
+
+  it('calls onUpdate hooks in most-recently-added order', async () => {
+    let events = []
+    let thisBinding = null
+
+    class MyComponent {
+      constructor () {
+        etch.onUpdate(this, this.onUpdateOne)
+        etch.onUpdate(this, this.onUpdateTwo)
+        etch.initialize(this)
+      }
+
+      async update () {
+        events.push('pre update')
+        await etch.update(this)
+        events.push('post update')
+      }
+
+      onUpdateOne () {
+        events.push('update 1')
+        thisBinding = this
+      }
+
+      onUpdateTwo () {
+        events.push('update 2')
+      }
+
+      render () { return <div /> }
+    }
+
+    let component = new MyComponent()
+    expect(events).to.eql([])
+    await component.update()
+    expect(events).to.eql(['pre update', 'update 1', 'update 2', 'post update'])
+    expect(thisBinding).to.equal(component)
+  })
 })


### PR DESCRIPTION
`etch.onUpdate(component, hook)` registers `hook` to be called any time `component` is updated via `etch.update` or `etch.updateSync`. This can be highly useful for complex components that update in many places and call out to imperative APIs.

/cc @nathansobo 