### PR TITLE
Improve update hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ console.log(component.element.outerHTML) // ==> <div>Salutations World!</div>
 
 There is also a synchronous variant, `etch.updateSync`, which performs the DOM update immediately. It doesn't skip redundant updates or batch together with other component updates, so you shouldn't really use it unless you have a clear reason.
 
-##### `etch.onUpdate(component, callback)`
+##### Update Hooks
 
-If you need to be notified when a component has been updated via `etch.update` or `etch.updateSync`, you can use `etch.onUpdate` to register a function to be called in those scenarios. Multiple functions can be registered per component, and the functions will be run in the same order that they are registered.
+If you need to perform imperative DOM interactions in addition to the declarative updates provided by etch, you can integrate your imperative code via update hooks on the component. To ensure good performance, it's important that you segregate DOM reads and writes in the appropriate hook.
+
+* `writeAfterUpdate` If you need to *write* to any part of the document as a result of updating your component, you should perform these writes in an optional `writeAfterUpdate` method defined on your component. Be warned: If you read from the DOM inside this method, it could potentially lead to layout thrashing by interleaving your reads with DOM writes associated with other components.
+
+* `readAfterUpdate` If you need to *read* any part of the document as a result of updating your component, you should perform these writes in an optional `readAfterUpdate` method defined on your component. You should avoid writing to the DOM in these methods, because writes could interleave with reads performed in `readAfterUpdate` hooks defined on other components. If you need to update the DOM as a result of your reads, store state on your component and request an additional update via `etch.update`.
 
 #### `etch.destroy(component[, removeNode])`
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ If you need to perform imperative DOM interactions in addition to the declarativ
 
 * `readAfterUpdate` If you need to *read* any part of the document as a result of updating your component, you should perform these writes in an optional `readAfterUpdate` method defined on your component. You should avoid writing to the DOM in these methods, because writes could interleave with reads performed in `readAfterUpdate` hooks defined on other components. If you need to update the DOM as a result of your reads, store state on your component and request an additional update via `etch.update`.
 
+These hooks exist to support DOM reads and writes in response to Etch updating your component's DOM. If you want your hook to run code based on changes to the component's *logical* state, you can make those calls directly or via other mechanisms. For example, if you simply want to call an external API when a property on your component changes, you should move that logic into the `update` method.
+
 #### `etch.destroy(component[, removeNode])`
 
 When you no longer need a component, pass it to `etch.destroy`. This function will call `destroy` on any child components (child components are covered later in this document), and will additionally remove the component's DOM element from the document unless `removeNode` is `false`. `etch.destroy` is also asynchronous so that it can combine the removal of DOM elements with other DOM updates, and it returns a promise that resolves when the component destruction process has completed.

--- a/src/component-helpers.js
+++ b/src/component-helpers.js
@@ -104,6 +104,12 @@ export function updateSync (component, replaceNode=true) {
     component.element = newDomNode
   }
 
+  // We can safely perform additional writes after a DOM update synchronously,
+  // but any reads need to be deferred until all writes are completed to avoid
+  // DOM thrashing. Requested reads occur at the end of the the current frame
+  // if this method was invoked via the scheduler. Otherwise, if `updateSync`
+  // was invoked outside of the scheduler, the default scheduler will defer
+  // reads until the next animation frame.
   if (typeof component.writeAfterUpdate === 'function') {
     component.writeAfterUpdate()
   }

--- a/src/component-helpers.js
+++ b/src/component-helpers.js
@@ -6,7 +6,6 @@ import refsStack from './refs-stack'
 import {getScheduler} from './scheduler-assignment'
 
 const componentsWithPendingUpdates = new WeakSet
-const updateHooks = new WeakMap
 let syncUpdatesInProgressCounter = 0
 let syncDestructionsInProgressCounter = 0
 
@@ -105,7 +104,14 @@ export function updateSync (component, replaceNode=true) {
     component.element = newDomNode
   }
 
-  callUpdateHooks(component)
+  if (typeof component.writeAfterUpdate === 'function') {
+    component.writeAfterUpdate()
+  }
+  if (typeof component.readAfterUpdate === 'function') {
+    getScheduler().readDocument(function () {
+      component.readAfterUpdate()
+    })
+  }
 
   syncUpdatesInProgressCounter--
 }
@@ -135,7 +141,6 @@ export function destroy (component, removeNode=true) {
 // Note that we track whether `destroy` calls are in progress and only remove
 // the element if we are not a nested call.
 export function destroySync (component, removeNode=true) {
-  updateHooks.delete(component)
   syncDestructionsInProgressCounter++
   destroyChildComponents(component.virtualElement)
   if (syncDestructionsInProgressCounter === 1 && removeNode) component.element.remove()
@@ -149,24 +154,5 @@ function destroyChildComponents(virtualNode) {
     }
   } else if (virtualNode.children) {
     virtualNode.children.forEach(destroyChildComponents)
-  }
-}
-
-// Registers a function to run after a component has been updated with
-// `update` or `updateSync`. Multiple functions can be registered per
-// component, and they will be called in insertion order.
-export function onUpdate (component, callback) {
-  let hooks = updateHooks.get(component)
-  if (!hooks) {
-    hooks = new Set()
-    updateHooks.set(component, hooks)
-  }
-  hooks.add(callback)
-}
-
-function callUpdateHooks (component) {
-  let hooks = updateHooks.get(component)
-  if (hooks) {
-    hooks.forEach(h => h.call(component))
   }
 }

--- a/test/unit/default-scheduler.test.js
+++ b/test/unit/default-scheduler.test.js
@@ -40,4 +40,63 @@ describe('DefaultScheduler', () => {
       expect(events).to.eql([1, 2, 3])
     })
   })
+
+  describe('.prototype.readDocument', () => {
+    describe('when document updates are pending', () => {
+      it('defers all requested reads until all requested updates are completed', async () => {
+        let events = []
+
+        scheduler.updateDocument(() => events.push('update 1'))
+        scheduler.readDocument(() => events.push('read 1'))
+        scheduler.updateDocument(() => events.push('update 2'))
+        scheduler.readDocument(() => events.push('read 2'))
+
+        expect(events).to.eql([])
+
+        await new Promise(requestAnimationFrame)
+
+        expect(events).to.eql(['update 1', 'update 2', 'read 1', 'read 2'])
+      })
+    })
+
+    describe('when document updates are in progress', () => {
+      it('defers all requested reads until all in-progress updates are completed', async () => {
+        let events = []
+
+        scheduler.updateDocument(() => {
+          events.push('update 1')
+          scheduler.readDocument(() => {
+            events.push('read 1')
+          })
+        })
+        scheduler.updateDocument(() => {
+          events.push('update 2')
+          scheduler.readDocument(() => {
+            events.push('read 2')
+          })
+        })
+
+        expect(events).to.eql([])
+
+        await new Promise(requestAnimationFrame)
+
+        expect(events).to.eql(['update 1', 'update 2', 'read 1', 'read 2'])
+      })
+    })
+
+    describe('when no document updates are pending or in progress', () => {
+      it('defers requested reads until the next animation frame for consistency', async () => {
+        let events = []
+
+        scheduler.readDocument(() => events.push('read 1'))
+        scheduler.readDocument(() => events.push('read 2'))
+
+        expect(events).to.eql([])
+
+        await new Promise(requestAnimationFrame)
+
+        expect(events).to.eql(['read 1', 'read 2'])
+      })
+    })
+  })
 })


### PR DESCRIPTION
@BinaryMuse I clearly see the need for update hooks, but I've had some new thoughts on how they should be implemented.

This PR implements update hooks as simple optional methods on the component object. This design addresses the following concerns:

* We should not invite users to bind update hooks from outside of a component, because this opens up the risk of users trying to associate hooks with a different version of etch than is used to implement the component. That could create confusion because different versions of etch won't share the same global WeakMap for hooks. If you can only implement hooks as a method on a component, this confusing scenario is impossible.
* Update hooks exist to perform manual DOM interaction, but we need to help users distinguish *reading* from *writing* to avoid the potential for layout thrash, where one component's synchronous DOM reads cause a reflow before another component has a chance to update.