### PR TITLE
Throw when undefined, null, or false returned from render()

### DIFF
--- a/src/component-helpers.js
+++ b/src/component-helpers.js
@@ -9,7 +9,7 @@ const componentsWithPendingUpdates = new WeakSet
 let syncUpdatesInProgressCounter = 0
 let syncDestructionsInProgressCounter = 0
 
-function validVirtualElement (virtualElement) {
+function isValidVirtualElement (virtualElement) {
   return virtualElement != null && virtualElement !== false
 }
 
@@ -33,7 +33,7 @@ export function initialize(component) {
   }
 
   let virtualElement = component.render()
-  if (!validVirtualElement(virtualElement)) {
+  if (!isValidVirtualElement(virtualElement)) {
     let namePart = component.constructor && component.constructor.name ? ' in ' + component.constructor.name : ''
     throw new Error('invalid falsy value ' + virtualElement + ' returned from render()' + namePart)
   }
@@ -99,7 +99,7 @@ export function update (component, replaceNode=true) {
 // between component objects and DOM elements for simplicity.
 export function updateSync (component, replaceNode=true) {
   let newVirtualElement = component.render()
-  if (!validVirtualElement(newVirtualElement)) {
+  if (!isValidVirtualElement(newVirtualElement)) {
     let namePart = component.constructor && component.constructor.name ? ' in ' + component.constructor.name : ''
     throw new Error('invalid falsy value ' + newVirtualElement + ' returned from render()' + namePart)
   }

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -29,4 +29,16 @@ describe('etch.initialize(component)', () => {
     expect(component.refs.greeting.textContent).to.equal('Hello')
     expect(component.refs.greeted.textContent).to.equal('World')
   })
+
+  it('throws an exception if undefined is returned from render', () => {
+    let component = {
+      render () {},
+
+      update () {}
+    }
+
+    expect(function() {
+      etch.initialize(component)
+    }).to.throw(/invalid falsy value/)
+  })
 })

--- a/test/unit/update-sync.test.js
+++ b/test/unit/update-sync.test.js
@@ -44,7 +44,7 @@ describe('etch.updateSync(component)', () => {
     component.greeted = 'Moon'
     etch.updateSync(component)
     expect(component.element.textContent).to.equal('Goodnight Moon')
-  });
+  })
 
   it('calls writeAfterUpdate and readAfterUpdate hooks at the appropriate times', async () => {
     let events = []
@@ -186,4 +186,39 @@ describe('etch.updateSync(component)', () => {
     component.update({childNodeType: 'span'})
     expect(component.element.firstChild.tagName).to.equal('SPAN')
   })
-});
+
+  it('throws a generic exception if undefined is returned from render in an anonymous component', () => {
+    let renderItem = true
+    let component = {
+      render () {
+        return renderItem && <div/>
+      },
+
+      update () {}
+    }
+
+    etch.initialize(component)
+    renderItem = false
+    expect(function() {
+      etch.updateSync(component)
+    }).to.throw(/invalid falsy value/)
+  })
+
+  it('throws a class-specific exception if undefined is returned from render in a named component', () => {
+    let renderItem = true
+    class MyComponent {
+      render () {
+        return renderItem && <div/>
+      }
+
+      update () {}
+    }
+
+    let component = new MyComponent()
+    etch.initialize(component)
+    renderItem = false
+    expect(function() {
+      etch.updateSync(component)
+    }).to.throw(/invalid falsy value.*in MyComponent/)
+  })
+})

--- a/test/unit/update-sync.test.js
+++ b/test/unit/update-sync.test.js
@@ -187,7 +187,7 @@ describe('etch.updateSync(component)', () => {
     expect(component.element.firstChild.tagName).to.equal('SPAN')
   })
 
-  it('throws a generic exception if undefined is returned from render in an anonymous component', () => {
+  it('throws a generic exception if undefined is returned from render in a component that is not a class instance', () => {
     let renderItem = true
     let component = {
       render () {
@@ -204,7 +204,7 @@ describe('etch.updateSync(component)', () => {
     }).to.throw(/invalid falsy value/)
   })
 
-  it('throws a class-specific exception if undefined is returned from render in a named component', () => {
+  it('throws a class-specific exception if undefined is returned from render in a component that is a class instance', () => {
     let renderItem = true
     class MyComponent {
       render () {


### PR DESCRIPTION
Useful to protect against

```javascript
render () {
  <div>some jsx</div>
}
```