### PR TITLE
Destroy old components when changing types in ComponentWidget

### DIFF
--- a/src/component-widget.js
+++ b/src/component-widget.js
@@ -72,6 +72,8 @@ export default class ComponentWidget {
         }
       }
 
+      // Clean up the old component
+      oldWidget.destroy()
       // Build a new component instance by calling `init`.
       this.init()
     }

--- a/test/unit/update-sync.test.js
+++ b/test/unit/update-sync.test.js
@@ -221,4 +221,49 @@ describe('etch.updateSync(component)', () => {
       etch.updateSync(component)
     }).to.throw(/invalid falsy value.*in MyComponent/)
   })
+
+  it('calls destroy on a replaced component', () => {
+    let updated = false
+    let destroyed = false
+    class ComponentA {
+      constructor () {
+        etch.initialize(this)
+      }
+
+      update () {}
+
+      render () { return <div>A</div> }
+
+      destroy () {
+        destroyed = true
+        etch.destroy(this)
+      }
+    }
+
+    class ComponentB {
+      constructor () {
+        etch.initialize(this)
+      }
+
+      update () {}
+
+      render () { return <div>B</div> }
+    }
+
+    let component = {
+      render () {
+        if (updated) { return <ComponentB /> } else { return <ComponentA /> }
+      },
+
+      update () {}
+    }
+
+    etch.initialize(component)
+    expect(component.element.textContent).to.equal('A')
+    expect(destroyed).to.equal(false)
+    updated = true
+    etch.updateSync(component)
+    expect(component.element.textContent).to.equal('B')
+    expect(destroyed).to.equal(true)
+  })
 })


### PR DESCRIPTION
@kuychaco and I were going over the code and discovered an edge case where `<TypeA />` would change to `<TypeB />` in the virtual DOM tree and the containing `ComponentWidget` would switch out the components, but wouldn't clean up the old one, potentially leaking resources.

/cc @nathansobo 