### PR TITLE
Update test to provide failing case

### DIFF
--- a/test/unit/update-sync.test.js
+++ b/test/unit/update-sync.test.js
@@ -252,7 +252,11 @@ describe('etch.updateSync(component)', () => {
 
     let component = {
       render () {
-        if (updated) { return <ComponentB /> } else { return <ComponentA /> }
+        if (updated) {
+          return <div><ComponentB /></div>
+        } else {
+          return <div><ComponentA /></div>
+        }
       },
 
       update () {}


### PR DESCRIPTION
@joefitzgerald I popped your test changes off master and opened a PR here to keep master passing. I also narrowed down the failure such that a minor change to an existing test makes it fail.

@nathansobo This is really interesting; an update that causes a parent to go from rendering `<ComponentA />` to `<ComponentB />` works fine, but one that causes it to go from rendering `<div><ComponentA /></div>` to `<div><ComponentB /></div>` does not.

The failure is:

```
  1) etch.updateSync(component) calls destroy on a replaced component:

      AssertionError: expected '' to equal 'B'
      + expected - actual

      +B

      at Context.<anonymous> (/Users/mtilley/github/etch/test/unit/update-sync.test.js:270:46)
      at tryOnImmediate (timers.js:534:15)
      at processImmediate [as _immediateCallback] (timers.js:514:5)
```