### PR TITLE
Fix the example for Handling Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ class ComponentWithEvents {
   }
 
   render () {
-    return <div on={click: this.didClick, focus: this.didFocus} />
+    return <div on={{click: this.didClick, focus: this.didFocus}} />
   }
 
   didClick (event) {


### PR DESCRIPTION
I ran into an issue with Handling Events example in the README. JSX seems to want to parse a template when the example is surrounded by only one pair of curly brackets, with two seeming to function as intended.