### PR TITLE
Support multi-dimensional refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,29 @@ component.refs.childComponent // This is a ChildComponent instance
 ```
 Note that `ref` properties on normal HTML elements create references to raw DOM nodes, while `ref` properties on child components create references to the constructed component object, which makes its DOM node available via its `element` property.
 
+`ref` can also be set to an array to create a sub key of the `refs` object.
+
+```js
+class ParentComponent {
+  constructor () {
+    etch.initialize(this)
+  }
+
+  render () {
+    <div>
+      <span ref={['greeting', 'span']}>Hello</span>
+      <ChildComponent ref={['greeting', 'child']} />
+    </div>
+  }
+}
+
+let component = new ParentComponent()
+component.refs.greeting.span // This is a span DOM node
+component.refs.greeting.child // This is a ChildComponent instance
+```
+
+Arrays can be used to set any depth on `refs`.
+
 ### Handling Events
 
 Etch supports listening to arbitrary events on DOM nodes via the special `on` property, which can be used to assign a hash of `eventName: listenerFunction` pairs:

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -1,5 +1,14 @@
 module.exports = {
-  build: function(refs, ref, component, flatRefs){
+  // This function adds the supplied component to the refs object at its ref point.
+  //
+  // `refs` is the refs object that the component needs adding to.
+  //
+  // `ref` is the string or array that defines its location in the object. This
+  // input is cast into an array so it can be iterated. This allows for inputs of
+  // 'refname' or ['ref', 'name'].
+  //
+  // `component` is the componet this ref relates to.
+  build: function(refs, ref, component){
     let tree = [].concat(ref)
     let level = refs
 
@@ -15,7 +24,14 @@ module.exports = {
     return refs
   },
 
-  clear: function(refs, ref, flatRefs){
+  // This function removes the ref from the refs object.
+  //
+  // `refs` is the refs object that the component needs removing from.
+  //
+  // `ref` is the string or array that defines its location in the object. This
+  // input is cast into an array so it can be iterated. This allows for inputs of
+  // 'refname' or ['ref', 'name'].
+  clear: function(refs, ref){
     let tree = [].concat(ref)
     let level = refs
 
@@ -31,7 +47,14 @@ module.exports = {
     return refs
   },
 
-  getFromValue: function(refs, ref, flatRefs){
+  // This function returns the component at the given ref.
+  //
+  // `refs` is the refs object that it needs retrieving from.
+  //
+  // `ref` is the string or array that defines its location in the object. This
+  // input is cast into an array so it can be iterated. This allows for inputs of
+  // 'refname' or ['ref', 'name'].
+  getFromValue: function(refs, ref){
     let tree = [].concat(ref)
     let level = refs
 

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -1,0 +1,36 @@
+module.exports = {
+  pattern: /([A-z]*?)\[(.*)\]/,
+
+  build: function(refs, ref, component){
+    if(this.pattern.test(ref)){
+      let m = this.pattern.exec(ref)
+      refs[m[1]] = this.build((refs[m[1]] || {}), m[2], component)
+    }else{
+      refs[ref] = component
+    }
+
+    return refs
+  },
+
+  clear: function(refs, ref){
+    if(this.pattern.test(ref)){
+      let m = this.pattern.exec(ref)
+      refs[m[1]] = this.clear((refs[m[1]] || {}), m[2])
+    }else{
+      delete refs[ref]
+    }
+
+    return refs
+  },
+
+  getFromValue: function(refs, ref){
+    if(this.pattern.test(ref)){
+      let m = this.pattern.exec(ref)
+      refs[m[1]] = this.getFromValue((refs[m[1]] || {}), m[2])
+      return refs
+    }else{
+      let value = refs[ref]
+      return value
+    }
+  }
+}

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -1,22 +1,6 @@
 module.exports = {
-  buildTree: function(tree, ref){
-    let pattern = /(\w+)|(\[(\w+)\])/g
-    let m
-
-    while((m = pattern.exec(ref)) !== null){
-      tree.push((m[1] || m[3]))
-    }
-
-    return tree
-  },
-
   build: function(refs, ref, component, flatRefs){
-    let tree
-    if(flatRefs){
-      tree = [ref]
-    }else{
-      tree = this.buildTree([], ref)
-    }
+    let tree = [].concat(ref)
     let level = refs
 
     for(let i = 0; i < tree.length; i++){
@@ -32,12 +16,7 @@ module.exports = {
   },
 
   clear: function(refs, ref, flatRefs){
-    let tree
-    if(flatRefs){
-      tree = [ref]
-    }else{
-      tree = this.buildTree([], ref)
-    }
+    let tree = [].concat(ref)
     let level = refs
 
     for(let i = 0; i < tree.length; i++){
@@ -53,12 +32,7 @@ module.exports = {
   },
 
   getFromValue: function(refs, ref, flatRefs){
-    let tree
-    if(flatRefs){
-      tree = [ref]
-    }else{
-      tree = this.buildTree([], ref)
-    }
+    let tree = [].concat(ref)
     let level = refs
 
     for(let i = 0; i < tree.length; i++){

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -34,12 +34,17 @@ module.exports = {
   clear: function(refs, ref){
     let tree = [].concat(ref)
     let level = refs
+    let pLevel = refs
+    let pKey = tree[0]
 
     for(let i = 0; i < tree.length; i++){
       if(tree[i + 1] == null){
         delete level[tree[i]]
+        if(Object.keys(level).length == 0) delete pLevel[pKey]
       }else{
         if(!level[tree[i]]) level[tree[i]] = {}
+        pLevel = level
+        pKey = tree[i]
         level = level[tree[i]]
       }
     }

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -1,36 +1,60 @@
 module.exports = {
   pattern: /([A-z]*?)\[(.*)\]/,
 
+  buildTree: function(tree, ref){
+    let pattern = /(\w+)|(\[(\w+)\])/g
+    let m
+
+    while((m = pattern.exec(ref)) !== null){
+      tree.push((m[1] || m[3]))
+    }
+
+    return tree
+  },
+
   build: function(refs, ref, component){
-    if(this.pattern.test(ref)){
-      let m = this.pattern.exec(ref)
-      refs[m[1]] = this.build((refs[m[1]] || {}), m[2], component)
-    }else{
-      refs[ref] = component
+    let tree = this.buildTree([], ref)
+    let level = refs
+
+    for(let i = 0; i < tree.length; i++){
+      if(tree[i + 1] == null){
+        level[tree[i]] = component
+      }else{
+        if(!level[tree[i]]) level[tree[i]] = {}
+        level = level[tree[i]]
+      }
     }
 
     return refs
   },
 
   clear: function(refs, ref){
-    if(this.pattern.test(ref)){
-      let m = this.pattern.exec(ref)
-      refs[m[1]] = this.clear((refs[m[1]] || {}), m[2])
-    }else{
-      delete refs[ref]
+    let tree = this.buildTree([], ref)
+    let level = refs
+
+    for(let i = 0; i < tree.length; i++){
+      if(tree[i + 1] == null){
+        delete level[tree[i]]
+      }else{
+        if(!level[tree[i]]) level[tree[i]] = {}
+        level = level[tree[i]]
+      }
     }
 
     return refs
   },
 
   getFromValue: function(refs, ref){
-    if(this.pattern.test(ref)){
-      let m = this.pattern.exec(ref)
-      refs[m[1]] = this.getFromValue((refs[m[1]] || {}), m[2])
-      return refs
-    }else{
-      let value = refs[ref]
-      return value
+    let tree = this.buildTree([], ref)
+    let level = refs
+
+    for(let i = 0; i < tree.length; i++){
+      if(tree[i + 1] == null){
+        return level[tree[i]]
+      }else{
+        if(!level[tree[i]]) level[tree[i]] = {}
+        level = level[tree[i]]
+      }
     }
   }
 }

--- a/lib/build-refs.js
+++ b/lib/build-refs.js
@@ -1,6 +1,4 @@
 module.exports = {
-  pattern: /([A-z]*?)\[(.*)\]/,
-
   buildTree: function(tree, ref){
     let pattern = /(\w+)|(\[(\w+)\])/g
     let m
@@ -12,8 +10,13 @@ module.exports = {
     return tree
   },
 
-  build: function(refs, ref, component){
-    let tree = this.buildTree([], ref)
+  build: function(refs, ref, component, flatRefs){
+    let tree
+    if(flatRefs){
+      tree = [ref]
+    }else{
+      tree = this.buildTree([], ref)
+    }
     let level = refs
 
     for(let i = 0; i < tree.length; i++){
@@ -28,8 +31,13 @@ module.exports = {
     return refs
   },
 
-  clear: function(refs, ref){
-    let tree = this.buildTree([], ref)
+  clear: function(refs, ref, flatRefs){
+    let tree
+    if(flatRefs){
+      tree = [ref]
+    }else{
+      tree = this.buildTree([], ref)
+    }
     let level = refs
 
     for(let i = 0; i < tree.length; i++){
@@ -44,8 +52,13 @@ module.exports = {
     return refs
   },
 
-  getFromValue: function(refs, ref){
-    let tree = this.buildTree([], ref)
+  getFromValue: function(refs, ref, flatRefs){
+    let tree
+    if(flatRefs){
+      tree = [ref]
+    }else{
+      tree = this.buildTree([], ref)
+    }
     let level = refs
 
     for(let i = 0; i < tree.length; i++){

--- a/lib/component-helpers.js
+++ b/lib/component-helpers.js
@@ -35,6 +35,9 @@ function initialize(component) {
     throw new Error('invalid falsy value ' + virtualNode + ' returned from render()' + namePart)
   }
 
+  // Use flat refs unless flag is set.
+  if(component.flatRefs === undefined) component.flatRefs = true
+
   component.refs = {}
   component.virtualNode = virtualNode
   component.element = render(component.virtualNode, {

--- a/lib/component-helpers.js
+++ b/lib/component-helpers.js
@@ -35,9 +35,6 @@ function initialize(component) {
     throw new Error('invalid falsy value ' + virtualNode + ' returned from render()' + namePart)
   }
 
-  // Use flat refs unless flag is set.
-  if(component.flatRefs === undefined) component.flatRefs = true
-
   component.refs = {}
   component.virtualNode = virtualNode
   component.element = render(component.virtualNode, {

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,7 @@ function render (virtualNode, options) {
       virtualNode.component = component
       domNode = component.element
       if (options && options.refs && ref) {
-        options.refs = buildRefs.build(options.refs, ref, component)
+        options.refs = buildRefs.build(options.refs, ref, component, component.flatRefs)
       }
     } else if (SVG_TAGS.has(tag)) {
       domNode = document.createElementNS("http://www.w3.org/2000/svg", tag);
@@ -29,7 +29,7 @@ function render (virtualNode, options) {
       domNode = document.createElement(tag)
       if(props && props.ref){
         if (options && options.refs && props.ref) {
-          options.refs = buildRefs.build(options.refs, props.ref, domNode)
+          options.refs = buildRefs.build(options.refs, props.ref, domNode, options.listenerContext && options.listenerContext.flatRefs)
         }
       }
       if (children) addChildren(domNode, children, options)

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,7 +19,7 @@ function render (virtualNode, options) {
       virtualNode.component = component
       domNode = component.element
       if (options && options.refs && ref) {
-        options.refs = buildRefs.build(options.refs, ref, component, component.flatRefs)
+        options.refs = buildRefs.build(options.refs, ref, component)
       }
     } else if (SVG_TAGS.has(tag)) {
       domNode = document.createElementNS("http://www.w3.org/2000/svg", tag);
@@ -29,7 +29,7 @@ function render (virtualNode, options) {
       domNode = document.createElement(tag)
       if(props && props.ref){
         if (options && options.refs && props.ref) {
-          options.refs = buildRefs.build(options.refs, props.ref, domNode, options.listenerContext && options.listenerContext.flatRefs)
+          options.refs = buildRefs.build(options.refs, props.ref, domNode)
         }
       }
       if (children) addChildren(domNode, children, options)

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,6 @@
 const updateProps = require('./update-props')
 const SVG_TAGS = require('./svg-tags')
+const buildRefs = require('./build-refs')
 
 function render (virtualNode, options) {
   let domNode
@@ -18,7 +19,7 @@ function render (virtualNode, options) {
       virtualNode.component = component
       domNode = component.element
       if (options && options.refs && ref) {
-        options.refs[ref] = component
+        options.refs = buildRefs.build(options.refs, ref, component)
       }
     } else if (SVG_TAGS.has(tag)) {
       domNode = document.createElementNS("http://www.w3.org/2000/svg", tag);
@@ -26,10 +27,16 @@ function render (virtualNode, options) {
       if (props) updateProps(domNode, null, virtualNode, options)
     } else {
       domNode = document.createElement(tag)
+      if(props && props.ref){
+        if (options && options.refs && props.ref) {
+          options.refs = buildRefs.build(options.refs, props.ref, domNode)
+        }
+      }
       if (children) addChildren(domNode, children, options)
       if (props) updateProps(domNode, null, virtualNode, options)
     }
   }
+
   virtualNode.domNode = domNode
   return domNode
 }

--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -14,7 +14,7 @@ module.exports = function (domNode, oldVirtualNode, newVirtualNode, options) {
     listenerContext = options.listenerContext
   }
   updateProps(domNode, oldVirtualNode, oldProps, newVirtualNode, newProps)
-  if (refs) updateRef(domNode, oldProps && oldProps.ref, newProps && newProps.ref, refs)
+  if (refs) updateRef(domNode, oldProps && oldProps.ref, newProps && newProps.ref, refs, listenerContext)
   updateEventListeners(domNode, oldVirtualNode, newVirtualNode, listenerContext)
 }
 
@@ -126,13 +126,13 @@ function updateAttributes (domNode, oldAttributes, newAttributes) {
   }
 }
 
-function updateRef (domNode, oldRefName, newRefName, refs) {
+function updateRef (domNode, oldRefName, newRefName, refs, listenerContext) {
   if (newRefName !== oldRefName) {
-    if(buildRefs.getFromValue(refs, oldRefName) === domNode){
-      refs = buildRefs.clear(refs, oldRefName)
+    if(buildRefs.getFromValue(refs, oldRefName, listenerContext && listenerContext.flatRefs) === domNode){
+      refs = buildRefs.clear(refs, oldRefName, listenerContext && listenerContext.flatRefs)
     }
   }
-  refs = buildRefs.build(refs, newRefName, domNode)
+  refs = buildRefs.build(refs, newRefName, domNode, listenerContext && listenerContext.flatRefs)
 }
 
 function updateEventListeners (domNode, oldVirtualNode, newVirtualNode, listenerContext) {

--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -131,11 +131,11 @@ function updateAttributes (domNode, oldAttributes, newAttributes) {
 
 function updateRef (domNode, oldRefName, newRefName, refs, listenerContext) {
   if (newRefName !== oldRefName) {
-    if(buildRefs.getFromValue(refs, oldRefName, listenerContext && listenerContext.flatRefs) === domNode){
-      refs = buildRefs.clear(refs, oldRefName, listenerContext && listenerContext.flatRefs)
+    if(buildRefs.getFromValue(refs, oldRefName) === domNode){
+      refs = buildRefs.clear(refs, oldRefName)
     }
   }
-  refs = buildRefs.build(refs, newRefName, domNode, listenerContext && listenerContext.flatRefs)
+  refs = buildRefs.build(refs, newRefName, domNode)
 }
 
 function updateEventListeners (domNode, oldVirtualNode, newVirtualNode, listenerContext) {

--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -135,7 +135,7 @@ function updateRef (domNode, oldRefName, newRefName, refs, listenerContext) {
       refs = buildRefs.clear(refs, oldRefName)
     }
   }
-  refs = buildRefs.build(refs, newRefName, domNode)
+  if (newRefName) refs = buildRefs.build(refs, newRefName, domNode)
 }
 
 function updateEventListeners (domNode, oldVirtualNode, newVirtualNode, listenerContext) {

--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -1,3 +1,4 @@
+const buildRefs = require('./build-refs')
 const EVENT_LISTENER_PROPS = require('./event-listener-props')
 const SVG_TAGS = require('./svg-tags')
 const SVG_ATTRIBUTE_TRANSLATIONS = require('./svg-attribute-translations')
@@ -127,9 +128,11 @@ function updateAttributes (domNode, oldAttributes, newAttributes) {
 
 function updateRef (domNode, oldRefName, newRefName, refs) {
   if (newRefName !== oldRefName) {
-    if (oldRefName && refs[oldRefName] === domNode) delete refs[oldRefName]
-    if (newRefName) refs[newRefName] = domNode
+    if(buildRefs.getFromValue(refs, oldRefName) === domNode){
+      refs = buildRefs.clear(refs, oldRefName)
+    }
   }
+  refs = buildRefs.build(refs, newRefName, domNode)
 }
 
 function updateEventListeners (domNode, oldVirtualNode, newVirtualNode, listenerContext) {

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -69,13 +69,12 @@ describe('etch.initialize(component)', () => {
   it('allows for multi dimensional refs', async function () {
     let component = {
       render () {
-        return <div ref='divs[first]'><div ref='divs[second]'>second</div></div>
+        return <div ref={['divs', 'first']}><div ref={['divs', 'second']}>second</div></div>
       },
 
       update () {}
     }
 
-    component.flatRefs = false
     etch.initialize(component)
 
     expect('divs[first]' in component.refs).to.be.false
@@ -84,32 +83,15 @@ describe('etch.initialize(component)', () => {
     expect(component.refs.divs.second.textContent).to.equal('second')
   })
 
-  it('should only use multi dimensional refs if flatRefs is false', async function () {
-    let component = {
-      render () {
-        return <div ref='divs[first]'><div ref='divs[second]'>second</div></div>
-      },
-
-      update () {}
-    }
-
-    component.flatRefs = true
-    etch.initialize(component)
-
-    expect('divs[first]' in component.refs).to.be.true
-    expect('divs' in component.refs).to.be.false
-  })
-
   it('allows for deep multi dimensional refs', async function () {
     let component = {
       render () {
-        return <div ref='divs[test][first]'>hello</div>
+        return <div ref={['divs', 'test', 'first']}>hello</div>
       },
 
       update () {}
     }
 
-    component.flatRefs = false
     etch.initialize(component)
 
     expect(component.refs.divs.test.first.textContent).to.equal('hello')
@@ -120,7 +102,7 @@ describe('etch.initialize(component)', () => {
     let component = {
       render () {
         return (<div>
-          <div ref={'tests[num_' + testNumber + ']'}>Testing</div>
+          <div ref={['tests', 'num_' + testNumber]}>Testing</div>
         </div>)
       },
 
@@ -129,7 +111,6 @@ describe('etch.initialize(component)', () => {
 
     let testNumber = 0
 
-    component.flatRefs = false
     etch.initialize(component)
 
     expect(component.refs.tests.num_0.textContent).to.equal('Testing')

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -77,7 +77,6 @@ describe('etch.initialize(component)', () => {
 
     etch.initialize(component)
 
-    expect('divs[first]' in component.refs).to.be.false
     expect('divs' in component.refs).to.be.true
     expect(component.refs.divs).to.have.all.keys(['first', 'second'])
     expect(component.refs.divs.second.textContent).to.equal('second')
@@ -95,7 +94,6 @@ describe('etch.initialize(component)', () => {
     etch.initialize(component)
 
     expect(component.refs.divs.test.first.textContent).to.equal('hello')
-    expect('divs[test][first]' in component.refs).to.be.false
   })
 
   it('allows updating multi dimensional refs', async function () {
@@ -120,5 +118,56 @@ describe('etch.initialize(component)', () => {
     await etch.update(component)
 
     expect(component.refs.tests.num_1.textContent).to.equal('Testing')
+  })
+
+  it('should remove refs in a logical manner', async function () {
+    let component = {
+      render () {
+        return (<div>
+          <div ref={['tests', testNumber, 'div']}>Testing</div>
+          <span ref={['tests', testNumber, 'span']}>Testing</span>
+          <p ref={['tests', 0, 'p']}>Testing</p>
+        </div>)
+      },
+
+      update () {}
+    }
+
+    process.throwThis = true
+
+    let testNumber = 0
+
+    etch.initialize(component)
+
+    expect(component.refs.tests[0].div.textContent).to.equal('Testing')
+    expect(component.refs.tests[0].span.textContent).to.equal('Testing')
+    expect(component.refs.tests[0].p.textContent).to.equal('Testing')
+
+    expect(Object.keys(component.refs).length).to.equal(1)
+    expect(Object.keys(component.refs.tests).length).to.equal(1)
+
+    testNumber = 1
+
+    await etch.update(component)
+
+    expect(component.refs.tests[1].div.textContent).to.equal('Testing')
+    expect(component.refs.tests[1].span.textContent).to.equal('Testing')
+    expect(component.refs.tests[0].p.textContent).to.equal('Testing')
+
+    expect(Object.keys(component.refs).length).to.equal(1)
+    expect(Object.keys(component.refs.tests).length).to.equal(2)
+
+    testNumber = 2
+
+    await etch.update(component)
+
+    expect(component.refs.tests[2].div.textContent).to.equal('Testing')
+    expect(component.refs.tests[2].span.textContent).to.equal('Testing')
+    expect(component.refs.tests[0].p.textContent).to.equal('Testing')
+
+    expect(Object.keys(component.refs).length).to.equal(1)
+    expect(Object.keys(component.refs.tests).length).to.equal(2)
+
+    process.throwThis = false
   })
 })

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -87,7 +87,7 @@ describe('etch.initialize(component)', () => {
   it('allows for deep multi dimensional refs', async function () {
     let component = {
       render () {
-        return <div ref='divs[test[first]]'>hello</div>
+        return <div ref='divs[test][first]'>hello</div>
       },
 
       update () {}

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -65,4 +65,60 @@ describe('etch.initialize(component)', () => {
       etch.initialize(component)
     }).to.throw(/invalid falsy value/)
   })
+
+  it('allows for multi dimensional refs', async function () {
+    let component = {
+      render () {
+        return <div ref='divs[first]'><div ref='divs[second]'>second</div></div>
+      },
+
+      update () {}
+    }
+
+    etch.initialize(component)
+
+    expect('divs[first]' in component.refs).to.be.false
+    expect('divs' in component.refs).to.be.true
+    expect(component.refs.divs).to.have.all.keys(['first', 'second'])
+    expect(component.refs.divs.second.textContent).to.equal('second')
+
+  })
+
+  it('allows for deep multi dimensional refs', async function () {
+    let component = {
+      render () {
+        return <div ref='divs[test[first]]'>hello</div>
+      },
+
+      update () {}
+    }
+
+    etch.initialize(component)
+
+    expect(component.refs.divs.test.first.textContent).to.equal('hello')
+  })
+
+  it('allows updating multi dimensional refs', async function () {
+    let component = {
+      render () {
+        return (<div>
+          <div ref={'tests[num_' + testNumber + ']'}>Testing</div>
+        </div>)
+      },
+
+      update () {}
+    }
+
+    let testNumber = 0
+
+    etch.initialize(component)
+
+    expect(component.refs.tests.num_0.textContent).to.equal('Testing')
+
+    testNumber = 1
+
+    await etch.update(component)
+
+    expect(component.refs.tests.num_1.textContent).to.equal('Testing')
+  })
 })

--- a/test/unit/initialize.test.js
+++ b/test/unit/initialize.test.js
@@ -75,13 +75,29 @@ describe('etch.initialize(component)', () => {
       update () {}
     }
 
+    component.flatRefs = false
     etch.initialize(component)
 
     expect('divs[first]' in component.refs).to.be.false
     expect('divs' in component.refs).to.be.true
     expect(component.refs.divs).to.have.all.keys(['first', 'second'])
     expect(component.refs.divs.second.textContent).to.equal('second')
+  })
 
+  it('should only use multi dimensional refs if flatRefs is false', async function () {
+    let component = {
+      render () {
+        return <div ref='divs[first]'><div ref='divs[second]'>second</div></div>
+      },
+
+      update () {}
+    }
+
+    component.flatRefs = true
+    etch.initialize(component)
+
+    expect('divs[first]' in component.refs).to.be.true
+    expect('divs' in component.refs).to.be.false
   })
 
   it('allows for deep multi dimensional refs', async function () {
@@ -93,9 +109,11 @@ describe('etch.initialize(component)', () => {
       update () {}
     }
 
+    component.flatRefs = false
     etch.initialize(component)
 
     expect(component.refs.divs.test.first.textContent).to.equal('hello')
+    expect('divs[test][first]' in component.refs).to.be.false
   })
 
   it('allows updating multi dimensional refs', async function () {
@@ -111,6 +129,7 @@ describe('etch.initialize(component)', () => {
 
     let testNumber = 0
 
+    component.flatRefs = false
     etch.initialize(component)
 
     expect(component.refs.tests.num_0.textContent).to.equal('Testing')


### PR DESCRIPTION
Allows refs to be multi-dimensional

```
<input type="checkbox" ref="selection[foo]" />
<input type="checkbox" ref="selection[bar]" />
```

can be accessed with `component.refs.selection.foo` and `component.refs.selection.bar`.

Can go as deep as you want.