### PR TITLE
Allow objects to be used to define styles.

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,5 @@
 * Consolidate old tests with new tests... what can be simpler?
 * Boolean attributes
 * Props that shouldn't be converted to attributes
-* Support for objects as the `style` prop
 * SVG
 * Benchmark

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,5 +1,6 @@
 const EVENT_LISTENER_PROPS = require('./event-listener-props')
 const SVG_TAGS = require('./svg-tags')
+const stylesObjectParser = require('./styles-object-parser')
 
 function dom (tag, props, ...children) {
   for (let i = 0; i < children.length;) {
@@ -37,6 +38,10 @@ function dom (tag, props, ...children) {
 
     if (props.class) {
       props.className = props.class
+    }
+
+    if (typeof props.style === 'object') {
+      props.style = stylesObjectParser(props.style)
     }
   }
 

--- a/lib/styles-object-parser.js
+++ b/lib/styles-object-parser.js
@@ -1,0 +1,49 @@
+// Turns an object into a string of styles.
+//
+// `stylesObject` is an object with keys matching the css names either
+// camel-cased or as style names (fontSize or font-size).
+module.exports = function(stylesObject){
+  let styles = []
+  let keys = Object.keys(stylesObject)
+
+  for(let i = 0; i < keys.length; i++){
+    let attribute = hyphenateName(keys[i])
+
+    styles.push(
+      attribute
+      + ': '
+      + ensureUnit(attribute, stylesObject[keys[i]])
+      + ';'
+    )
+  }
+
+  return styles.join(' ')
+}
+
+// Turns a camel-cased name into a hyphenated name
+//
+// fontSize becomes font-size
+function hyphenateName(keyName){
+  return keyName.replace(/[A-Z]/, '-$&').toLowerCase()
+}
+
+// Turns a number in a `px` value if needed.
+//
+// Takes the `attribute` that this value is for and the `value`.
+function ensureUnit(attribute, value){
+  if(NO_UNIT_TAGS.indexOf(attribute) != -1 || !(typeof value === 'number')){
+    return value
+  }else{
+    return value + 'px'
+  }
+}
+
+// List of css properties that do no need units on numbers.
+const NO_UNIT_TAGS = [
+  'animation-iteration-count', 'box-flex', 'box-flex-group',
+  'box-ordinal-group', 'column-count', 'fill-opacity', 'flex', 'flex-grow',
+  'flex-positive', 'flex-shrink', 'flex-negative', 'flexoOrder', 'grid-row',
+  'grid-column', 'font-weight', 'line-clamp', 'line-height', 'opacity', 'order',
+  'orphans', 'stop-opacity', 'stroke-dashoffset', 'stroke-opacity',
+  'stroke-width', 'tab-size', 'widows', 'z-index', 'zoom'
+]

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -438,4 +438,25 @@ describe('etch.dom', () => {
       })
     })
   })
+
+  describe('object styles', () => {
+    it('should still accept strings', () => {
+      let element = etch.dom.div({style: 'color: #fff;'})
+
+      expect(element.props.style).to.equal('color: #fff;')
+    })
+
+    it('should turn an object into a string', () => {
+      let element = etch.dom.div({
+        style: {
+          color: '#fff',
+          fontSize: 10,
+          padding: '10px',
+          zIndex: 1
+        }
+      })
+
+      expect(element.props.style).to.equal('color: #fff; font-size: 10px; padding: 10px; z-index: 1;')
+    })
+  })
 })


### PR DESCRIPTION
Allows the style prop to be given an object as well as a string.

```javascript
style: {
  color: '#fff',
  fontSize: 10,
  padding: '10px',
  zIndex: 1
}

// becomes

'color: #fff; font-size: 10px; padding: 10px; z-index: 1;'
```

The implementation is a bit rough and ready but if you want features like auto-prefixing etc... it would be best to use an existing npm module. As Etch is aimed at Atom/Electron I don't think we need too much _fancy_ here as in an Atom package you would have a stylesheet and classes.