### PR TITLE
doubleclick -> dblclick

### DIFF
--- a/lib/event-listener-props.js
+++ b/lib/event-listener-props.js
@@ -15,7 +15,7 @@ module.exports = {
   onSubmit: 'submit',
   onClick: 'click',
   onContextMenu: 'contextmenu',
-  onDoubleClick: 'doubleclick',
+  onDoubleClick: 'dblclick',
   onDrag: 'drag',
   onDragEnd: 'dragend',
   onDragEnter: 'dragenter',


### PR DESCRIPTION
As far as I can tell, `doubleclick` should be `dblclick`

https://developer.mozilla.org/en-US/docs/Web/Events/dblclick