### PR TITLE
Remove duplicate onError event listener property

### DIFF
--- a/lib/event-listener-props.js
+++ b/lib/event-listener-props.js
@@ -62,7 +62,6 @@ module.exports = {
   onVolumeChange: 'volumechange',
   onWaiting: 'waiting',
   onLoad: 'load',
-  onError: 'error',
   onAnimationStart: 'animationstart',
   onAnimationEnd: 'animationend',
   onAnimationIteration: 'animationiteration',


### PR DESCRIPTION
This PR removes a duplicate `onError` property from the event listener properties.  There's currently one on [line 48](https://github.com/atom/etch/blob/6fe9f4e4962967a3e5ef23b0d039b4f7a3b6b83b/lib/event-listener-props.js#L48).