### PR TITLE
Function refs

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,5 +1,6 @@
 const render = require('./render')
 const updateProps = require('./update-props')
+const updateRef = require('./update-ref')
 
 function patch (oldVirtualNode, newVirtualNode, options) {
   const oldNode = oldVirtualNode.domNode
@@ -40,15 +41,8 @@ function updateComponent (oldVirtualNode, newVirtualNode, options) {
   const {component, props: oldProps} = oldVirtualNode
   let {props: newProps, children: newChildren} = newVirtualNode
   newVirtualNode.component = component
-  if (options && options.refs) {
-    const refs = options.refs
-    const oldRefName = oldProps && oldProps.ref
-    const newRefName = newProps && newProps.ref
-    if (newRefName !== oldRefName) {
-      if (oldRefName && refs[oldRefName] === component) delete refs[oldRefName]
-      if (newRefName) refs[newRefName] = component
-    }
-  }
+  const refs = options && options.refs
+  if (refs) updateRef(component, oldProps && oldProps.ref, newProps && newProps.ref, refs)
   component.update(newProps || {}, newChildren)
   return component.element
 }
@@ -136,10 +130,12 @@ function removeVirtualNode (virtualNode, refs, removeDOMNode = true) {
   const {domNode, props, children, component} = virtualNode
   const ref = props && props.ref
   if (component) {
-    if (refs && ref && refs[ref] === component) delete refs[ref]
+    if (typeof ref === 'function') ref(undefined)
+    else if (refs && ref && refs[ref] === component) delete refs[ref]
     if (component.destroy) component.destroy()
   } else {
-    if (refs && ref && refs[ref] === domNode) delete refs[ref]
+    if (typeof ref === 'function') ref(undefined)
+    else if (refs && ref && refs[ref] === domNode) delete refs[ref]
     if (children) {
       for (let i = 0; i < children.length; i++) {
         removeVirtualNode(children[i], refs, false)

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -130,11 +130,11 @@ function removeVirtualNode (virtualNode, refs, removeDOMNode = true) {
   const {domNode, props, children, component} = virtualNode
   const ref = props && props.ref
   if (component) {
-    if (typeof ref === 'function') ref(undefined)
+    if (typeof ref === 'function') ref(null)
     else if (refs && ref && refs[ref] === component) delete refs[ref]
     if (component.destroy) component.destroy()
   } else {
-    if (typeof ref === 'function') ref(undefined)
+    if (typeof ref === 'function') ref(null)
     else if (refs && ref && refs[ref] === domNode) delete refs[ref]
     if (children) {
       for (let i = 0; i < children.length; i++) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -17,7 +17,9 @@ function render (virtualNode, options) {
       const component = new tag(props || {}, children)
       virtualNode.component = component
       domNode = component.element
-      if (options && options.refs && ref) {
+      if (typeof ref === "function") {
+        ref(component)
+      } else if (options && options.refs && ref) {
         options.refs[ref] = component
       }
     } else if (SVG_TAGS.has(tag)) {

--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -3,6 +3,8 @@ const SVG_TAGS = require('./svg-tags')
 const SVG_ATTRIBUTE_TRANSLATIONS = require('./svg-attribute-translations')
 const EMPTY = ''
 
+const updateRef = require('./update-ref')
+
 module.exports = function (domNode, oldVirtualNode, newVirtualNode, options) {
   const oldProps = oldVirtualNode && oldVirtualNode.props
   const newProps = newVirtualNode.props
@@ -113,13 +115,6 @@ function updateAttributes (domNode, oldAttributes, newAttributes) {
         domNode.setAttribute(name, newValue)
       }
     }
-  }
-}
-
-function updateRef (domNode, oldRefName, newRefName, refs) {
-  if (newRefName !== oldRefName) {
-    if (oldRefName && refs[oldRefName] === domNode) delete refs[oldRefName]
-    if (newRefName) refs[newRefName] = domNode
   }
 }
 

--- a/lib/update-ref.js
+++ b/lib/update-ref.js
@@ -1,6 +1,6 @@
 module.exports = function updateRef (domNode, oldRefName, newRefName, refs) {
   if (newRefName !== oldRefName) {
-    if (typeof oldRefName === 'function') oldRefName(undefined)
+    if (typeof oldRefName === 'function') oldRefName(null)
     else if (oldRefName && refs[oldRefName] === domNode) delete refs[oldRefName]
     if (typeof newRefName === 'function') newRefName(domNode)
     else if (newRefName) refs[newRefName] = domNode

--- a/lib/update-ref.js
+++ b/lib/update-ref.js
@@ -1,0 +1,8 @@
+module.exports = function updateRef (domNode, oldRefName, newRefName, refs) {
+  if (newRefName !== oldRefName) {
+    if (typeof oldRefName === 'function') oldRefName(undefined)
+    else if (oldRefName && refs[oldRefName] === domNode) delete refs[oldRefName]
+    if (typeof newRefName === 'function') newRefName(domNode)
+    else if (newRefName) refs[newRefName] = domNode
+  }
+}

--- a/test/unit/function-refs.js
+++ b/test/unit/function-refs.js
@@ -1,0 +1,293 @@
+/** @jsx etch.dom */
+
+const etch = require('../../lib/index')
+
+describe('function refs', () => {
+  it('work', async function () {
+    let saved_node
+    let component = {
+      render () {
+        return <div ref={ node => saved_node = node }>some text</div>
+      },
+
+      update () {}
+    }
+
+    etch.initialize(component)
+
+    expect(saved_node).to.exist
+    expect(saved_node.textContent).to.equal('some text')
+  })
+
+  it('allow updating', async function () {
+    let saved_nodes = []
+    const refFunc = num => node => saved_nodes[num] = node
+    let component = {
+      render () {
+        return (<div>
+          <div ref={refFunc(testNumber)}>Testing</div>
+        </div>)
+      },
+
+      update () {}
+    }
+
+    let testNumber = 0
+
+    etch.initialize(component)
+
+    expect(saved_nodes[0].textContent).to.equal('Testing')
+    expect(saved_nodes[1]).not.to.exist
+
+    testNumber = 1
+
+    await etch.update(component)
+
+    expect(saved_nodes[0]).not.to.exist
+    expect(saved_nodes[1].textContent).to.equal('Testing')
+  })
+
+  it('allow switching from text to function and back', async function () {
+    let saved_node
+    const refFunc = [
+      'savedNode',
+      node => saved_node = node
+    ]
+    let component = {
+      render () {
+        return (<div>
+          <div ref={refFunc[testNumber]}>Testing</div>
+        </div>)
+      },
+
+      update () {}
+    }
+
+    let testNumber = 0
+
+    etch.initialize(component)
+
+    expect(component.refs.savedNode.textContent).to.equal('Testing')
+    expect(saved_node).not.to.exist
+
+    testNumber = 1
+
+    await etch.update(component)
+
+    expect(saved_node.textContent).to.equal('Testing')
+    expect(component.refs.savedNode).not.to.exist
+
+    testNumber = 0
+
+    await etch.update(component)
+
+    expect(component.refs.savedNode.textContent).to.equal('Testing')
+    expect(saved_node).not.to.exist
+  })
+
+  it('are removed correctly', async function () {
+    let saved_nodes = {}
+    let refFunc = name => node => saved_nodes[name] = node
+    let component = {
+      render () {
+        return (<div>
+          {testNumber <= 2 ? <div ref={refFunc('div')}>Testing {testNumber}</div> : null}
+          {testNumber <= 1 ? <span ref={refFunc('span')}>Testing {testNumber}</span> : null}
+          {testNumber <= 0 ?<p ref={refFunc('p')}>Testing {testNumber}</p> : null}
+        </div>)
+      },
+
+      update () {}
+    }
+
+    process.throwThis = true
+
+    let testNumber = 0
+
+    etch.initialize(component)
+
+    expect(saved_nodes.div.textContent).to.equal('Testing 0')
+    expect(saved_nodes.span.textContent).to.equal('Testing 0')
+    expect(saved_nodes.p.textContent).to.equal('Testing 0')
+
+    testNumber = 1
+
+    await etch.update(component)
+
+    expect(saved_nodes.div.textContent).to.equal('Testing 1')
+    expect(saved_nodes.span.textContent).to.equal('Testing 1')
+    expect(saved_nodes.p).not.to.exist
+
+    testNumber = 2
+
+    await etch.update(component)
+
+    expect(saved_nodes.div.textContent).to.equal('Testing 2')
+    expect(saved_nodes.span).not.to.exist
+    expect(saved_nodes.p).not.to.exist
+
+    testNumber = 3
+
+    await etch.update(component)
+
+    expect(saved_nodes.div).not.to.exist
+    expect(saved_nodes.span).not.to.exist
+    expect(saved_nodes.p).not.to.exist
+
+    process.throwThis = false
+  })
+
+  describe('work similarly for components', () => {
+    class Component {
+      constructor(props, children) {
+        this.props = props
+        this.children = children
+        etch.initialize(this)
+      }
+      update(props, children) {
+        this.props = props
+        this.children = children
+        return etch.update(this)
+      }
+      render() {
+        return etch.dom('div', {}, this.children)
+      }
+      destroy() {
+        return etch.destroy(this)
+      }
+    }
+    it('work', async function () {
+      let saved_node
+      let component = {
+        render () {
+          return <Component ref={ node => saved_node = node }>some text</Component>
+        },
+
+        update () {}
+      }
+
+      etch.initialize(component)
+
+      expect(saved_node).to.exist
+      expect(saved_node.element.textContent).to.equal('some text')
+    })
+
+    it('allow updating', async function () {
+      let saved_nodes = []
+      const refFunc = num => node => saved_nodes[num] = node
+      let component = {
+        render () {
+          return (<div>
+            <Component ref={refFunc(testNumber)}>Testing</Component>
+          </div>)
+        },
+
+        update () {}
+      }
+
+      let testNumber = 0
+
+      etch.initialize(component)
+
+      expect(saved_nodes[0].element.textContent).to.equal('Testing')
+      expect(saved_nodes[1]).not.to.exist
+
+      testNumber = 1
+
+      await etch.update(component)
+
+      expect(saved_nodes[0]).not.to.exist
+      expect(saved_nodes[1].element.textContent).to.equal('Testing')
+    })
+
+    it('allow switching from text to function and back', async function () {
+      let saved_node
+      const refFunc = [
+        'savedNode',
+        node => saved_node = node
+      ]
+      let component = {
+        render () {
+          return (<div>
+            <Component ref={refFunc[testNumber]}>Testing</Component>
+          </div>)
+        },
+
+        update () {}
+      }
+
+      let testNumber = 0
+
+      etch.initialize(component)
+
+      expect(component.refs.savedNode.element.textContent).to.equal('Testing')
+      expect(saved_node).not.to.exist
+
+      testNumber = 1
+
+      await etch.update(component)
+
+      expect(saved_node.element.textContent).to.equal('Testing')
+      expect(component.refs.savedNode).not.to.exist
+
+      testNumber = 0
+
+      await etch.update(component)
+
+      expect(component.refs.savedNode.element.textContent).to.equal('Testing')
+      expect(saved_node).not.to.exist
+    })
+
+    it('are removed correctly', async function () {
+      let saved_nodes = {}
+      let refFunc = name => node => saved_nodes[name] = node
+      let component = {
+        render () {
+          return (<div>
+            {testNumber <= 2 ? <Component ref={refFunc('Component')}>Testing {testNumber}</Component> : null}
+            {testNumber <= 1 ? <span ref={refFunc('span')}>Testing {testNumber}</span> : null}
+            {testNumber <= 0 ?<p ref={refFunc('p')}>Testing {testNumber}</p> : null}
+          </div>)
+        },
+
+        update () {}
+      }
+
+      process.throwThis = true
+
+      let testNumber = 0
+
+      etch.initialize(component)
+
+      expect(saved_nodes.Component.element.textContent).to.equal('Testing 0')
+      expect(saved_nodes.span.textContent).to.equal('Testing 0')
+      expect(saved_nodes.p.textContent).to.equal('Testing 0')
+
+      testNumber = 1
+
+      await etch.update(component)
+
+      expect(saved_nodes.Component.element.textContent).to.equal('Testing 1')
+      expect(saved_nodes.span.textContent).to.equal('Testing 1')
+      expect(saved_nodes.p).not.to.exist
+
+      testNumber = 2
+
+      await etch.update(component)
+
+      expect(saved_nodes.Component.element.textContent).to.equal('Testing 2')
+      expect(saved_nodes.span).not.to.exist
+      expect(saved_nodes.p).not.to.exist
+
+      testNumber = 3
+
+      await etch.update(component)
+
+      expect(saved_nodes.Component).not.to.exist
+      expect(saved_nodes.span).not.to.exist
+      expect(saved_nodes.p).not.to.exist
+
+      process.throwThis = false
+    })
+  })
+})

--- a/test/unit/function-refs.js
+++ b/test/unit/function-refs.js
@@ -37,13 +37,13 @@ describe('function refs', () => {
     etch.initialize(component)
 
     expect(saved_nodes[0].textContent).to.equal('Testing')
-    expect(saved_nodes[1]).not.to.exist
+    expect(saved_nodes[1]).to.be.undefined
 
     testNumber = 1
 
     await etch.update(component)
 
-    expect(saved_nodes[0]).not.to.exist
+    expect(saved_nodes[0]).to.be.null
     expect(saved_nodes[1].textContent).to.equal('Testing')
   })
 
@@ -68,21 +68,21 @@ describe('function refs', () => {
     etch.initialize(component)
 
     expect(component.refs.savedNode.textContent).to.equal('Testing')
-    expect(saved_node).not.to.exist
+    expect(saved_node).to.be.undefined
 
     testNumber = 1
 
     await etch.update(component)
 
     expect(saved_node.textContent).to.equal('Testing')
-    expect(component.refs.savedNode).not.to.exist
+    expect(component.refs.savedNode).to.be.undefined
 
     testNumber = 0
 
     await etch.update(component)
 
     expect(component.refs.savedNode.textContent).to.equal('Testing')
-    expect(saved_node).not.to.exist
+    expect(saved_node).to.be.null
   })
 
   it('are removed correctly', async function () {
@@ -116,23 +116,23 @@ describe('function refs', () => {
 
     expect(saved_nodes.div.textContent).to.equal('Testing 1')
     expect(saved_nodes.span.textContent).to.equal('Testing 1')
-    expect(saved_nodes.p).not.to.exist
+    expect(saved_nodes.p).to.be.null
 
     testNumber = 2
 
     await etch.update(component)
 
     expect(saved_nodes.div.textContent).to.equal('Testing 2')
-    expect(saved_nodes.span).not.to.exist
-    expect(saved_nodes.p).not.to.exist
+    expect(saved_nodes.span).to.be.null
+    expect(saved_nodes.p).to.be.null
 
     testNumber = 3
 
     await etch.update(component)
 
-    expect(saved_nodes.div).not.to.exist
-    expect(saved_nodes.span).not.to.exist
-    expect(saved_nodes.p).not.to.exist
+    expect(saved_nodes.div).to.be.null
+    expect(saved_nodes.span).to.be.null
+    expect(saved_nodes.p).to.be.null
 
     process.throwThis = false
   })
@@ -190,13 +190,13 @@ describe('function refs', () => {
       etch.initialize(component)
 
       expect(saved_nodes[0].element.textContent).to.equal('Testing')
-      expect(saved_nodes[1]).not.to.exist
+      expect(saved_nodes[1]).to.be.undefined
 
       testNumber = 1
 
       await etch.update(component)
 
-      expect(saved_nodes[0]).not.to.exist
+      expect(saved_nodes[0]).to.be.null
       expect(saved_nodes[1].element.textContent).to.equal('Testing')
     })
 
@@ -221,21 +221,21 @@ describe('function refs', () => {
       etch.initialize(component)
 
       expect(component.refs.savedNode.element.textContent).to.equal('Testing')
-      expect(saved_node).not.to.exist
+      expect(saved_node).to.be.undefined
 
       testNumber = 1
 
       await etch.update(component)
 
       expect(saved_node.element.textContent).to.equal('Testing')
-      expect(component.refs.savedNode).not.to.exist
+      expect(component.refs.savedNode).to.be.undefined
 
       testNumber = 0
 
       await etch.update(component)
 
       expect(component.refs.savedNode.element.textContent).to.equal('Testing')
-      expect(saved_node).not.to.exist
+      expect(saved_node).to.be.null
     })
 
     it('are removed correctly', async function () {
@@ -269,23 +269,23 @@ describe('function refs', () => {
 
       expect(saved_nodes.Component.element.textContent).to.equal('Testing 1')
       expect(saved_nodes.span.textContent).to.equal('Testing 1')
-      expect(saved_nodes.p).not.to.exist
+      expect(saved_nodes.p).to.be.null
 
       testNumber = 2
 
       await etch.update(component)
 
       expect(saved_nodes.Component.element.textContent).to.equal('Testing 2')
-      expect(saved_nodes.span).not.to.exist
-      expect(saved_nodes.p).not.to.exist
+      expect(saved_nodes.span).to.be.null
+      expect(saved_nodes.p).to.be.null
 
       testNumber = 3
 
       await etch.update(component)
 
-      expect(saved_nodes.Component).not.to.exist
-      expect(saved_nodes.span).not.to.exist
-      expect(saved_nodes.p).not.to.exist
+      expect(saved_nodes.Component).to.be.null
+      expect(saved_nodes.span).to.be.null
+      expect(saved_nodes.p).to.be.null
 
       process.throwThis = false
     })


### PR DESCRIPTION
As discussed in https://github.com/atom/etch/pull/50#issuecomment-322491087, accepting a function as a value for `ref` property seems like a pretty lucrative idea.

So I was tired of waiting until someone else does that, and here's my stab at it.

The change itself is somewhat trivial, but I should say that I have only a passing knowledge of etch's code base, so I might've missed some corner cases here or there. I hope someone with a more in-depth knowledge could advise me.

Tests are somewhat wordy, mostly because it should work pretty much the same for both 'standard' dom nodes and Etch components, hence the test-suite is basically repeated twice. Tests are far from being comprehensive but should cover the most basic stuff.

A point of discussion, I'm not sure whether when a component is deleted, or `ref` value is changed, the `ref` function should be called with `undefined` or `null`. I personally find that while `null` has its uses, in most cases it's interchangeable with `undefined`, so I try to avoid it in my code (because it's impossible to avoid `undefined`). But since Etch already seems to prefer `null` in some cases, maybe using `null` here would be more consistent. FWIW, React uses `null`:

> React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts.

(from https://reactjs.org/docs/refs-and-the-dom.html)

Won't argue with either, ~~but for now, I used `undefined` mostly due to the force of habit.~~

Update: changed to `null` for the sake of consistency if nothing else.

One thing to keep in mind. Using stuff like this

```jsx
// ...
render() {
  return <div ref={node => this.div = node}>...</div>
}
// ...
```

will likely kill rendering performance, because

1. Arrow function would be re-created on each render
2. New arrow function won't ever be strict-equal to old arrow function, so `updateRef` would be executed on each render (which means `ref` would be called *twice* per render)

React's documentation actually suggests doing this, and I don't know how they get around the issue. There is, however, a straightforward workaround available: have a bound function defined outside of `render`

```jsx
// ...
constructor() {
  this.updateDivRef = node => this.div = node
  // ...
  etch.initialize(this)
}
// ...
render() {
  return <div ref={this.updateDivRef}>...</div>
}
// ...
```

TODO: 

- [ ] Decide on `undefined` vs `null`
- [ ] Add some documentation to README.