### PR TITLE
Add support for `false` as child

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -21,6 +21,13 @@ function dom (tag, props, ...children) {
         }
         break;
 
+      case 'boolean':
+        if (!child) {
+          children.splice(i, 1)
+          break;
+        }
+        /* fallthrough */
+
       default:
         throw new Error(`Invalid child node: ${child}`)
     }

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -52,16 +52,12 @@ describe('etch.dom', () => {
     expect(component.element.outerHTML).to.equal('<svg><circle></circle></svg>')
   })
 
-  it('ignores nulls passed in the place of children, but throws an error if other invalid values are passed', () => {
+  it('ignores nulls and false passed in the place of children, but throws an error if other invalid values are passed', () => {
     const element = etch.render(
-      <div><span/>{null}<p/></div>
+      <div><span/>{null}{false}<p/></div>
     );
 
     expect(Array.from(element.children).map(c => c.tagName)).to.eql(['SPAN', 'P'])
-
-    expect(() => etch.render(
-      <div>{false}</div>
-    )).to.throw('Invalid child node: false')
 
     expect(() => etch.render(
       <div>{undefined}</div>


### PR DESCRIPTION
This allows the following notation:
```jsx
render() {
  const {on} = this.props;

  return <div>{on && 'Is on'}</div>;
}
```
Where `on` is a boolean
  