### PR TITLE
Add support for reverting the value of a controlled input or select

### DIFF
--- a/lib/update-props.js
+++ b/lib/update-props.js
@@ -55,17 +55,23 @@ function updateProps (domNode, oldVirtualNode, oldProps, newVirtualNode, newProp
         updateNestedProps(domNode.style, oldValue, newValue, true)
       } else if (name === 'attributes') {
         updateAttributes(domNode, oldValue, newValue)
-      } else {
-        if (newValue !== oldValue) {
-          if (name !== 'innerHTML' && newVirtualNode && SVG_TAGS.has(newVirtualNode.tag)) {
-            domNode.setAttribute(SVG_ATTRIBUTE_TRANSLATIONS.get(name) || name, newValue)
-          } else if (newVirtualNode && newVirtualNode.tag === 'input'
-            && name === 'value' && domNode[name] === newValue) {
-            // Do not update `value` of an `input` unless it differs.
-            // Every change will reset the cursor position.
-          } else {
-            domNode[name] = newValue
-          }
+      } else if (
+        name === 'value' &&
+        newVirtualNode && (
+          newVirtualNode.tag === 'input' ||
+          newVirtualNode.tag === 'select'
+        )
+      ) {
+        // Do not update `value` of an `input` unless it differs.
+        // Every change will reset the cursor position.
+        if (domNode[name] !== newValue) {
+          domNode[name] = newValue
+        }
+      } else if (newValue !== oldValue) {
+        if (name !== 'innerHTML' && newVirtualNode && SVG_TAGS.has(newVirtualNode.tag)) {
+          domNode.setAttribute(SVG_ATTRIBUTE_TRANSLATIONS.get(name) || name, newValue)
+        } else {
+          domNode[name] = newValue
         }
       }
     }


### PR DESCRIPTION
Imagine you want a "controlled" color picker, so write the following:
```jsx
class ColorPicker {
  constructor(props) {
    this.props = props;
    etch.initialize(this);
  }
  handleChange(event) {
    const value = event.target.value;

    if (value !== this.props.value) {
      // revert the value so that it stays consistent with the `props`
      // this is the part that doesn't currently work <------------------------------
      etch.update(this);

      // notify the parent of the change
      this.props.onChange(value);
    }
  }
  render() {
    return <input {...this.props} type="color" onChange={this.handleChange} />;
  }
  update(nextProps) {
    if (shallowDiffers(this.props, nextProps)) {
      this.props = nextProps;
      etch.update(this);
    }
  }
}
```

And imagine you want to have an instance that refuses some colors:
```js
const picker = new ColorPicker({value: '#fff', onChange: handleChange});
document.body.appendChild(picker.element)

function handleChange(color) {
  if (color.endsWith('ff')) {
    // color must have the blue at max
    picker.update({value: color, onChange: handleChange});
  }
}
```

This is not currently possible because when the `etch.update(this)` in the `handleChange` is called, it calls `updateProps` which updates the `input.value` only if the new value is `!==` than the old one.
But in this case the new value is always `===` the old one.
Ref. [lib/update-props.js:59](https://github.com/atom/etch/blob/master/lib/update-props.js#L59)

This PR solves this case for `input` and `select` type elements.