### PR TITLE
Avoid race conditions on destroy

### DIFF
--- a/lib/component-helpers.js
+++ b/lib/component-helpers.js
@@ -188,6 +188,7 @@ function destroySync (component, removeNode=true) {
 }
 
 function destroyChildComponents(virtualNode) {
+  if (!virtualNode) { return }
   if (virtualNode.component && typeof virtualNode.component.destroy === 'function') {
     virtualNode.component.destroy()
   } else if (virtualNode.children) {


### PR DESCRIPTION
When `destroySync` is called, it's possible for the components properties to have been deleted before the update scheduler runs. One package causing this is atom `about` https://github.com/atom/about/issues/72